### PR TITLE
Simplify Firebase Admin SDK config to use base64 encoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,9 +27,12 @@ NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789012:web:abcdef123456
 # Firebase Admin SDK (for server-side operations)
 # Get this from: Firebase Console > Project Settings > Service Accounts > Generate new private key
 # IMPORTANT: Keep this secret! Never expose in client-side code
-FIREBASE_ADMIN_PROJECT_ID=your-project-id
-FIREBASE_ADMIN_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project-id.iam.gserviceaccount.com
-FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYourPrivateKeyHere\n-----END PRIVATE KEY-----\n"
+#
+# To generate the base64 key:
+# 1. Download the service account JSON file from Firebase Console
+# 2. Run: cat service-account.json | base64 -w 0
+# 3. Paste the output below
+FIREBASE_SERVICE_ACCOUNT_KEY_BASE64=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6InlvdXItcHJvamVjdC1pZCIsInByaXZhdGVfa2V5X2lkIjoieW91ci1rZXktaWQiLCJwcml2YXRlX2tleSI6Ii0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLVxuWW91clByaXZhdGVLZXlIZXJlXG4tLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tXG4iLCJjbGllbnRfZW1haWwiOiJmaXJlYmFzZS1hZG1pbnNkay14eHh4eEB5b3VyLXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJjbGllbnRfaWQiOiJ5b3VyLWNsaWVudC1pZCIsImF1dGhfdXJpIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLCJ0b2tlbl91cmkiOiJodHRwczovL29hdXRoMi5nb29nbGVhcGlzLmNvbS90b2tlbiIsImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL29hdXRoMi92MS9jZXJ0cyIsImNsaWVudF94NTA5X2NlcnRfdXJsIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vcm9ib3QvdjEvbWV0YWRhdGEveDUwOS95b3VyLWVtYWlsIn0=
 
 # ============================================
 # Token Encryption


### PR DESCRIPTION
- Changed from separate PROJECT_ID, CLIENT_EMAIL, PRIVATE_KEY fields
- Now uses single FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 variable
- Added clear instructions on how to generate the base64 key
- Simpler to deploy and manage in production environments