### PR TITLE
Fix app integration connection errors on settings

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -43,12 +43,18 @@ export default function DashboardLayout({
   children: ReactNode;
 }) {
   const [isSidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const { user, loading } = useAuth();
+  const { user, userData, loading } = useAuth();
   const router = useRouter();
 
   // Redirect to login if not authenticated
   if (!loading && !user) {
     router.push("/login");
+    return null;
+  }
+
+  // Redirect to setup if user doesn't have a team
+  if (!loading && user && userData && !userData.teamId) {
+    router.push("/setup");
     return null;
   }
 

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -249,7 +249,9 @@ const Integrations = ({ teamId, teamData, onDisconnectIntegration }: {
 
     const handleConnectClick = (providerId: string) => {
         if (!teamId) {
-            alert("Team information not available. Cannot connect.");
+            alert("Team information not available. Please complete the setup process first.");
+            // Redirect to setup page to complete team setup
+            window.location.href = "/setup";
             return;
         }
         setIsConnecting(providerId);

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -22,7 +22,7 @@ const IntegrationsSetupStep = lazy(() =>
 type SetupStep = "team" | "voice" | "integrations";
 
 export default function SetupPage() {
-  const { user, userData, loading: authLoading } = useAuth();
+  const { user, userData, loading: authLoading, refreshUserData } = useAuth();
   const [setupStep, setSetupStep] = useState<SetupStep>("team");
   const [teamId, setTeamId] = useState<string | null>(null);
   const router = useRouter();
@@ -43,8 +43,10 @@ export default function SetupPage() {
     }
   }, [user, userData, authLoading, router]);
 
-  const handleTeamComplete = (newTeamId: string) => {
+  const handleTeamComplete = async (newTeamId: string) => {
     setTeamId(newTeamId);
+    // Refresh user data to get the updated teamId
+    await refreshUserData();
     setSetupStep("voice");
   };
 


### PR DESCRIPTION
Fixed the "Team information not available. Cannot connect." error that prevented users from integrating apps like Jira, Slack, GitHub, Notion, and ClickUp.

Root Cause:
- Dashboard layout only checked user authentication, not team membership
- Users could bypass team setup and access settings without a teamId
- Integration connections require teamId, causing failures

Changes:
1. Dashboard Layout (app/dashboard/layout.tsx)
   - Added userData to useAuth hook
   - Added check to redirect users to /setup if teamId is missing
   - Ensures all dashboard pages require completed team setup

2. Setup Page (app/setup/page.tsx)
   - Added refreshUserData call after team creation
   - Ensures AuthProvider has latest userData with teamId

3. Settings Page (app/dashboard/settings/page.tsx)
   - Improved error message for missing teamId
   - Added redirect to setup page as fallback
   - Better user experience with clearer instructions

Result:
- Users must complete team setup before accessing dashboard
- Integration connections now work properly with valid teamId
- Prevents future occurrences of this error