### PR TITLE
Fix client-side error on sign out

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -64,7 +64,8 @@ export default function DashboardLayout({
     }
   }, [user, userData, loading, router]);
 
-  if (loading) {
+  // Show loading state during auth changes or when user/userData is missing
+  if (loading || !user) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-background">
         <div className="flex flex-col items-center space-y-4 fade-in">


### PR DESCRIPTION
Added guard to prevent rendering dashboard when user is null:
- Show loading screen if loading OR !user
- Prevents accessing user properties during sign out
- Fixes 'Application error: a client-side exception has occurred'

This ensures smooth sign out without client-side crashes.